### PR TITLE
Add maintainability and test coverage badges from Code Climate

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,4 @@
 # slack-events-relay
+
+[![Maintainability](https://api.codeclimate.com/v1/badges/83d1fba8a9ddaab579e9/maintainability)](https://codeclimate.com/github/stripethree/slack-events-relay/maintainability)
+[![Test Coverage](https://api.codeclimate.com/v1/badges/83d1fba8a9ddaab579e9/test_coverage)](https://codeclimate.com/github/stripethree/slack-events-relay/test_coverage)


### PR DESCRIPTION
## Why are we doing this?

Code Climate provides some automated code review, which could be useful given this is a one-person project. I would like to have it be a part of my normal workflow to better assess its value.

## Did you document your work?

I set up the repo in Code Climate as open source and copied the badge code into the `README`

## How can someone test these changes?

View the badge in the `README` and follow the link to see the analysis of the code in this repo.

## What possible risks or adverse effects are there?

None identified.

## What are the follow-up tasks?

None identified.

## Are there any known issues?

None identified.