### PR TITLE
Update Travis CI configuration to push coverage to Code Climate

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,8 @@
 language: node_js
 node_js:
   - "8"
+after_script:
+  npm install codeclimate-test-reporter
+  npm run coverage
+  ./node_modules/.bin/codeclimate-test-reporter < coverage/lcov.info
+  

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: node_js
 node_js:
   - "8"
 after_script:
-  npm install codeclimate-test-reporter
-  npm run coverage
-  ./node_modules/.bin/codeclimate-test-reporter < coverage/lcov.info
-  
+  - npm install codeclimate-test-reporter
+  - npm run coverage
+  - ./node_modules/.bin/codeclimate-test-reporter < coverage/lcov.info

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,3 +5,5 @@ after_script:
   - npm install codeclimate-test-reporter
   - npm run coverage
   - ./node_modules/.bin/codeclimate-test-reporter < coverage/lcov.info
+notifications:
+  - email: false


### PR DESCRIPTION
## Why are we doing this?

In #8, I forgot to add the additional configuration that will push coverage information to Code Climate.

## Did you document your work?

No `README` changes necessary.

I started with [this documentation from Travis CI](https://docs.travis-ci.com/user/code-climate/), which took me to [this documentation from Code Climate](https://docs.codeclimate.com/docs/travis-ci-test-coverage) which then pointed me to [this example](https://github.com/codeclimate/test-reporter/blob/master/examples/javascript_examples.md).

## How can someone test these changes?

Trust the build output?

<img width="576" alt="screen shot 2018-07-02 at 1 26 34 pm" src="https://user-images.githubusercontent.com/1305168/42184803-978d14ea-7dfb-11e8-8c65-dcbbd6301a9b.png">


## What possible risks or adverse effects are there?

None identified.

## What are the follow-up tasks?

None identified.

## Are there any known issues?

None identified.