### PR TITLE
Add error reporting with Sentry

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ The _dev_ target assumes [_nodemon_] is installed and available globally; it is 
 
 ## Logging and metrics
 
-**TODO**: The [debug] package is for a firehose of data sent to stdout/stderr
+The [debug] package is for a firehose of data sent to stdout/stderr
 
 [debug]: https://github.com/visionmedia/debug
 

--- a/README.md
+++ b/README.md
@@ -38,8 +38,11 @@ The _dev_ target assumes [_nodemon_] is installed and available globally; it is 
 
 | Key | Required? | Default? |
 |-|-|-|
-| `PORT` | Y | 8080 |
+| `API_KEY` | Y | _none_ |
+| `PORT` | N | 8080 |
+| `SENTRY_DSN` | N | _none_
 | `SLACK_BOT_TOKEN` | Y | _none_ |
+| `SLACK_CHANNEL_ID` | Y | _none _ |
 
 ### Endpoints
 

--- a/example.env
+++ b/example.env
@@ -1,2 +1,3 @@
 API_KEY=test-api-key
 SLACK_BOT_TOKEN=xoxb-slack_bot_token
+SLACK_CHANNEL_ID=slack-channel-id

--- a/package-lock.json
+++ b/package-lock.json
@@ -521,6 +521,11 @@
       "integrity": "sha1-tUc7M9yXxCTl2Y3IfVXU2KKci/I=",
       "dev": true
     },
+    "charenc": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/charenc/-/charenc-0.0.2.tgz",
+      "integrity": "sha1-wKHS86cJLgN3S/qD8UwPxXkKhmc="
+    },
     "ci-info": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-1.1.3.tgz",
@@ -646,6 +651,11 @@
         "shebang-command": "^1.2.0",
         "which": "^1.2.9"
       }
+    },
+    "crypt": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/crypt/-/crypt-0.0.2.tgz",
+      "integrity": "sha1-iNf/fsDfuG9xPch7u0LQRNPmxBs="
     },
     "debug": {
       "version": "3.1.0",
@@ -1552,6 +1562,11 @@
       "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
       "dev": true
     },
+    "is-buffer": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
+    },
     "is-builtin-module": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
@@ -1833,6 +1848,16 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.1.tgz",
       "integrity": "sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA=="
+    },
+    "md5": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/md5/-/md5-2.2.1.tgz",
+      "integrity": "sha1-U6s41f48iJG6RlMp6iP6wFQBJvk=",
+      "requires": {
+        "charenc": "~0.0.1",
+        "crypt": "~0.0.1",
+        "is-buffer": "~1.1.1"
+      }
     },
     "media-typer": {
       "version": "0.3.0",
@@ -4402,6 +4427,18 @@
       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.0.tgz",
       "integrity": "sha1-9JvmtIeJTdxA3MlKMi9hEJLgDV4="
     },
+    "raven": {
+      "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/raven/-/raven-2.6.3.tgz",
+      "integrity": "sha512-bKre7qlDW+y1+G2bUtCuntdDYc8o5v1T233t0vmJfbj8ttGOgLrGRlYB8saelVMW9KUAJNLrhFkAKOwFWFJonw==",
+      "requires": {
+        "cookie": "0.3.1",
+        "md5": "^2.2.1",
+        "stack-trace": "0.0.10",
+        "timed-out": "4.0.1",
+        "uuid": "3.0.0"
+      }
+    },
     "raw-body": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.3.3.tgz",
@@ -4725,6 +4762,11 @@
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
       "dev": true
     },
+    "stack-trace": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
+      "integrity": "sha1-VHxws0fo0ytOEI6hoqFZ5f3eGcA="
+    },
     "statuses": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.4.0.tgz",
@@ -4964,6 +5006,11 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
       "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM="
+    },
+    "uuid": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.0.0.tgz",
+      "integrity": "sha1-Zyj8BFnEUNeWqZwxg3VpvfZy1yg="
     },
     "validate-npm-package-license": {
       "version": "3.0.3",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
     "@slack/client": "^4.3.1",
     "body-parser": "^1.18.3",
     "debug": "^3.1.0",
-    "express": "^4.16.3"
+    "express": "^4.16.3",
+    "raven": "^2.6.3"
   },
   "devDependencies": {
     "eslint": "^5.0.1",

--- a/src/index.js
+++ b/src/index.js
@@ -2,11 +2,18 @@ const bodyParser = require('body-parser');
 const debug = require('debug')('relay-app');
 const express = require('express');
 const logError = require('debug')('relay-app:error');
+const Raven = require('raven');
 const { Slack } = require('./slack');
 
 const app = express();
 
 const slack = new Slack(process.env.SLACK_BOT_TOKEN);
+
+if (process.env.SENTRY_DSN) {
+  Raven.config(process.env.SENTRY_DSN, {
+    captureUnhandledRejections: true
+  }).install();
+}
 
 // HELPERS
 const API_KEY = process.env.API_KEY;


### PR DESCRIPTION
## Why are we doing this?

Adds error reporting with [Sentry](https://sentry.io/welcome/).

## Did you document your work?

[Documentation for setting up Sentry](https://docs.sentry.io/clients/node/)

Updated `README` with the new env key and some others I forgot to add.

## How can someone test these changes?

Running this:
`SENTRY_DSN=<sentry-dsn> PORT=FAIL npm run dev`

Will trigger an error that gets reported to Sentry.

## What possible risks or adverse effects are there?

It's another account to remember. Do I really need this? Who knows.

## What are the follow-up tasks?

Configure email alerts within Sentry before it gets annoying.

## Are there any known issues?

None identified.